### PR TITLE
so9p_test.go: fix typo so that `go test so9p` works again

### DIFF
--- a/src/so9p/so9p_test.go
+++ b/src/so9p/so9p_test.go
@@ -19,8 +19,8 @@ func TestStartServer(t *testing.T) {
 		DebugPrint = false
 		S := new(So9ps)
 		S.Path = "/"
-		S.AddFS("/", &LocalFileNode{})
-		S.AddFS("/ramfs", &RamFSnode{})
+		AddFS("/", &LocalFileNode{})
+		AddFS("/ramfs", &RamFSnode{})
 		rpc.Register(S)
 		l, err := net.Listen("tcp", ":1234")
 		if err != nil {


### PR DESCRIPTION
This fixes:

```
GOPATH=`pwd` go test so9p
```

Note however that I wasn't able to execute the instructions in the readme.
